### PR TITLE
Update unit test and Fix bug

### DIFF
--- a/asciiTextArt.go
+++ b/asciiTextArt.go
@@ -1,18 +1,30 @@
 package asciitextart
 
-// This method only support a~z A-Z 0~9
+// For now, This method only support a~z A~Z 0~9
+// If you input a string with other characters(not include in a~z A~Z 0~9), this method will return ""
 func ToAsciiTextArt(str string) string {
-	res := lettersConver([]byte(str))
+	res := lettersConver([]rune(str))
 	return res
 }
 
-func lettersConver(b []byte) string {
+func lettersConver(b []rune) string {
 	str := make([]string, 10)
 	for i := 0; i < len(b); i++ {
 		if b[i] >= 'a' && b[i] <= 'z' {
 			for j := 0; j < 10; j++ {
 				str[j] += lowercase[int(b[i]-'a')*10+j]
 			}
+		} else if b[i] >= 'A' && b[i] <= 'Z' {
+			for j := 0; j < 10; j++ {
+				str[j] += uppercase[int(b[i]-'A')*10+j]
+			}
+		} else if b[i] >= '0' && b[i] <= '9' {
+			for j := 0; j < 10; j++ {
+				str[j] += numbercase[int(b[i]-'0')*10+j]
+			}
+		} else {
+			// This branch should not be reached
+			return ""
 		}
 	}
 	var res string

--- a/asciiTextArt_test.go
+++ b/asciiTextArt_test.go
@@ -6,6 +6,12 @@ import (
 )
 
 func TestToAsciiTextArt(t *testing.T) {
-	res:=asciitextart.ToAsciiTextArt("welcome")
-	t.Log(res)
+	res1:=asciitextart.ToAsciiTextArt("welcome")
+	t.Log(res1)
+	res2:=asciitextart.ToAsciiTextArt("hello, 世界")
+	if res2==""{
+		t.Log("OK!")
+	}else{
+		t.Fatal("Error!")
+	}
 }


### PR DESCRIPTION
1. Add new return when input a string with other characters(not include in a~z A~Z 0~9).
2. change parameters from []byte to []rune to avoid crash when input other characters.